### PR TITLE
식별키를 생성하는 유틸 클래스

### DIFF
--- a/src/main/java/com/studyveloper/overtheflow/util/IdentifierGenerator.java
+++ b/src/main/java/com/studyveloper/overtheflow/util/IdentifierGenerator.java
@@ -1,0 +1,27 @@
+package com.studyveloper.overtheflow.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class IdentifierGenerator {
+	public static String generateId(Integer key) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-1");
+			md.update(key.toString().getBytes());
+			MessageDigest generator = (MessageDigest)md.clone();
+			byte[] identifier = generator.digest();
+			StringBuffer sb = new StringBuffer(); 
+            for(int i=0; i<identifier.length; i++) {
+                sb.append(Integer.toString((identifier[i]&0xff) + 0x100, 16).substring(1));
+            }
+ 
+            return sb.toString();
+        } catch(NoSuchAlgorithmException e){
+            e.printStackTrace();
+            return "error";
+		} catch (CloneNotSupportedException ex) {
+			ex.printStackTrace();
+			return "error";
+		}
+	}
+}


### PR DESCRIPTION
식별키 생성을 위해 생성할 대상의 키값의 해시코드를 전달하여 sha-1 알고리즘을 통해 식별키를 반환합니다.